### PR TITLE
ng_sniffer: added ng version of sniffer application

### DIFF
--- a/ng_sniffer/Makefile
+++ b/ng_sniffer/Makefile
@@ -1,0 +1,21 @@
+# Set the name of your application:
+APPLICATION = ng_sniffer
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= native
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../../RIOT
+
+# Define modules that are used
+USEMODULE += ng_netif
+USEMODULE += auto_init_ng_netif
+USEMODULE += uart0
+USEMODULE += shell
+USEMODULE += shell_commands
+USEMODULE += ps
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+include $(RIOTBASE)/Makefile.include

--- a/ng_sniffer/README.md
+++ b/ng_sniffer/README.md
@@ -1,0 +1,12 @@
+About
+=====
+
+This application is build to run together with the script `RIOTBASE/dist/tools/ng_sniffer/ng_sniffer.py` as sniffer for (wireless) data traffic. This application works with any board with any network device that supports the gnrc network stack (or precisely the gnrc parts up to the link-layer). Further the network device (and it's driver) needs to support promiscuous and raw mode for usable output. Finally the board needs to include auto-initialization code for the targeted network device.
+
+
+Usage
+=====
+
+Compile and flash this application to the board of your choice. You can check if everything on the RIOT side works by connecting to the board via UART and by checking with `ifconfig` if a network device is available. Further you can check with `ifconfig 4 promisc` if promiscuous mode is supported and with `ifconfig 4 raw` if raw mode is supported by the driver/network device.
+
+For further information on setting up the host part, see `RIOTBASE/dist/tools/ng_snifffer/README.md`.

--- a/ng_sniffer/main.c
+++ b/ng_sniffer/main.c
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    app_sniffer
+ * @brief       Sniffer application based on the new network stack
+ * @{
+ *
+ * @file
+ * @brief       Sniffer application for RIOT
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "thread.h"
+#include "hwtimer.h"
+#include "shell.h"
+#include "shell_commands.h"
+#include "posix_io.h"
+#include "board_uart0.h"
+#include "net/ng_netbase.h"
+
+/**
+ * @brief   Buffer size used by the shell
+ */
+#define SHELL_BUFSIZE           (64U)
+
+/**
+ * @brief   Priority of the RAW dump thread
+ */
+#define RAWDUMP_PRIO            (THREAD_PRIORITY_MAIN - 1)
+
+/**
+ * @brief   Stack for the raw dump thread
+ */
+static char rawdmp_stack[THREAD_STACKSIZE_MAIN];
+
+/**
+ * @brief   Make a raw dump of the given packet contents
+ */
+void dump_pkt(ng_pktsnip_t *pkt)
+{
+    ng_pktsnip_t *snip = pkt;
+
+    printf("rftest-rx --- len 0x%02x lqi 0x%02x rx_time 0x%08lx\n\n",
+           ng_pkt_len(pkt), 0, hwtimer_now());
+
+    while (snip) {
+        for (size_t i = 0; i < snip->size; i++) {
+            printf("0x%02x ", ((uint8_t *)(snip->data))[i]);
+        }
+        snip = snip->next;
+    }
+    puts("\n");
+
+    ng_pktbuf_release(pkt);
+}
+
+/**
+ * @brief   Event loop of the RAW dump thread
+ *
+ * @param[in] arg   unused parameter
+ */
+void *rawdump(void *arg)
+{
+    (void)arg;
+    msg_t msg;
+
+    while (1) {
+        msg_receive(&msg);
+
+        switch (msg.type) {
+            case NG_NETAPI_MSG_TYPE_RCV:
+                dump_pkt((ng_pktsnip_t *)msg.content.ptr);
+                break;
+            default:
+                /* do nothing */
+                break;
+        }
+    }
+
+    /* never reached */
+    return NULL;
+}
+
+/**
+ * @brief   Maybe you are a golfer?!
+ */
+int main(void)
+{
+    shell_t shell;
+    ng_netreg_entry_t dump;
+
+    puts("RIOT sniffer application");
+
+    /* start and register rawdump thread */
+    puts("Run the rawdump thread and register it");
+    dump.pid = thread_create(rawdmp_stack, sizeof(rawdmp_stack), RAWDUMP_PRIO,
+                             CREATE_STACKTEST, rawdump, NULL, "rawdump");
+    dump.demux_ctx = NG_NETREG_DEMUX_CTX_ALL;
+    ng_netreg_register(NG_NETTYPE_UNDEF, &dump);
+
+    /* start the shell */
+    puts("All ok, starting the shell now");
+    (void) posix_open(uart0_handler_pid, 0);
+    shell_init(&shell, NULL, SHELL_BUFSIZE, uart0_readc, uart0_putc);
+    shell_run(&shell);
+
+    return 0;
+}


### PR DESCRIPTION
This is the adaption of the existing sniffer application to work with the new network stack.

This PR works so far only with `at86rf2xx` drivers, e.g. with the `iot-lab_M3` or the `samr21-xpro` boards.