### PR TITLE
ng_sniffer: use uart0 only for none newlib boards

### DIFF
--- a/ng_sniffer/Makefile
+++ b/ng_sniffer/Makefile
@@ -10,7 +10,6 @@ RIOTBASE ?= $(CURDIR)/../../RIOT
 # Define modules that are used
 USEMODULE += ng_netif_default
 USEMODULE += auto_init_ng_netif
-USEMODULE += uart0
 USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps

--- a/ng_sniffer/main.c
+++ b/ng_sniffer/main.c
@@ -25,8 +25,12 @@
 #include "hwtimer.h"
 #include "shell.h"
 #include "shell_commands.h"
-#include "posix_io.h"
-#include "board_uart0.h"
+#ifdef MODULE_NEWLIB
+#   include "uart_stdio.h"
+#else
+#   include "posix_io.h"
+#   include "board_uart0.h"
+#endif
 #include "net/ng_netbase.h"
 
 /**
@@ -111,8 +115,12 @@ int main(void)
 
     /* start the shell */
     puts("All ok, starting the shell now");
+#ifndef MODULE_NEWLIB
     (void) posix_open(uart0_handler_pid, 0);
     shell_init(&shell, NULL, SHELL_BUFSIZE, uart0_readc, uart0_putc);
+#else
+    shell_init(&shell, NULL, SHELL_BUFSIZE, getchar, putchar);
+#endif
     shell_run(&shell);
 
     return 0;


### PR DESCRIPTION
Related and dependent on https://github.com/RIOT-OS/RIOT/pull/3555