### PR TITLE
openwsn: remove vtimer, use xtimer

### DIFF
--- a/openwsn/Makefile
+++ b/openwsn/Makefile
@@ -18,7 +18,7 @@ CFLAGS += -DDEVELHELP
 export QUIET ?= 1
 
 USEMODULE += ps
-USEMODULE += vtimer
+USEMODULE += xtimer
 USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += posix

--- a/openwsn/main.c
+++ b/openwsn/main.c
@@ -20,7 +20,7 @@
 
 #include <stdio.h>
 
-#include "vtimer.h"
+#include "xtimer.h"
 #include "shell.h"
 #include "posix_io.h"
 #include "03oos_openwsn.h"


### PR DESCRIPTION
`vtimer` does not exist anymore.

For what was the `vtimer` used before? Maybe we can omit the timer completely instead of just replacing it with `xtimer`?