### PR TITLE
sniffer: Update to follow gnrc_netreg_entry_t API change

### DIFF
--- a/sniffer/main.c
+++ b/sniffer/main.c
@@ -101,7 +101,7 @@ int main(void)
 
     /* start and register rawdump thread */
     puts("Run the rawdump thread and register it");
-    dump.pid = thread_create(rawdmp_stack, sizeof(rawdmp_stack), RAWDUMP_PRIO,
+    dump.target.pid = thread_create(rawdmp_stack, sizeof(rawdmp_stack), RAWDUMP_PRIO,
                              THREAD_CREATE_STACKTEST, rawdump, NULL, "rawdump");
     dump.demux_ctx = GNRC_NETREG_DEMUX_CTX_ALL;
     gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &dump);


### PR DESCRIPTION
The sniffer wasn't compiling after https://github.com/RIOT-OS/RIOT/pull/5526 was merged