### PR TITLE
sniffer: update to match xtimer API changes

### DIFF
--- a/sniffer/main.c
+++ b/sniffer/main.c
@@ -50,7 +50,7 @@ void dump_pkt(gnrc_pktsnip_t *pkt)
     gnrc_pktsnip_t *snip = pkt;
 
     printf("rftest-rx --- len 0x%02x lqi 0x%02x rx_time 0x%08" PRIx64 "\n\n",
-           gnrc_pkt_len(pkt), 0, xtimer_now64());
+           gnrc_pkt_len(pkt), 0, xtimer_usec_from_ticks64(xtimer_now64()));
 
     while (snip) {
         for (size_t i = 0; i < snip->size; i++) {

--- a/sniffer/main.c
+++ b/sniffer/main.c
@@ -49,8 +49,10 @@ void dump_pkt(gnrc_pktsnip_t *pkt)
 {
     gnrc_pktsnip_t *snip = pkt;
 
-    printf("rftest-rx --- len 0x%02x lqi 0x%02x rx_time 0x%08" PRIx64 "\n\n",
-           gnrc_pkt_len(pkt), 0, xtimer_usec_from_ticks64(xtimer_now64()));
+    uint64_t now_us = xtimer_usec_from_ticks64(xtimer_now64());
+
+    printf("rftest-rx --- len 0x%02x lqi 0x%02x rx_time 0x%08" PRIx32 "%08" PRIx32 "\n\n",
+           gnrc_pkt_len(pkt), 0, (uint32_t)(now_us >> 32), (uint32_t)(now_us & 0xffffffff));
 
     while (snip) {
         for (size_t i = 0; i < snip->size; i++) {


### PR DESCRIPTION
Updated to fix compilation errors after some xtimer API changes. Changed printf to avoid relying on support in printf for 64 bit numbers, since it is a trivial workaround when printing in hex and some newlib builds may not have this support for code size reasons.