### PR TITLE
sniffer: remove gnrc_netif header; read LQI

### DIFF
--- a/sniffer/main.c
+++ b/sniffer/main.c
@@ -48,11 +48,14 @@ static char rawdmp_stack[THREAD_STACKSIZE_MAIN];
 void dump_pkt(gnrc_pktsnip_t *pkt)
 {
     gnrc_pktsnip_t *snip = pkt;
+    gnrc_netif_hdr_t *netif_hdr = pkt->next->data;
+    uint8_t lqi = netif_hdr->lqi;
 
+    pkt = gnrc_pktbuf_remove_snip(pkt, pkt->next);
     uint64_t now_us = xtimer_usec_from_ticks64(xtimer_now64());
 
     printf("rftest-rx --- len 0x%02x lqi 0x%02x rx_time 0x%08" PRIx32 "%08" PRIx32 "\n\n",
-           gnrc_pkt_len(pkt), 0, (uint32_t)(now_us >> 32), (uint32_t)(now_us & 0xffffffff));
+           gnrc_pkt_len(pkt), lqi, (uint32_t)(now_us >> 32), (uint32_t)(now_us & 0xffffffff));
 
     while (snip) {
         for (size_t i = 0; i < snip->size; i++) {


### PR DESCRIPTION
Since the device is in raw mode, we don't have any network layer
modules included and we subscribe to `GNRC_NETTYPE_UNDEF` it is safe
to assume that `pkt->next` in `dump_pkt()` is the `gnrc_netif` header.
This only contains GNRC-internal information and should thus be removed
from the dump (though Wireshark seems to be okay with the extra bytes,
a reader of the raw data might be confused).

Since this header however contains the LQI, which the sniffer claims to
output but always returns 0, the LQI value in the `gnrc_netif` header
is read and set before the deletion of that header.