### PR TITLE
sniffer: add message queue for dumper thread

### DIFF
--- a/sniffer/main.c
+++ b/sniffer/main.c
@@ -38,6 +38,11 @@
 #define RAWDUMP_PRIO            (THREAD_PRIORITY_MAIN - 1)
 
 /**
+ * @brief   Message queue size of the RAW dump thread
+ */
+#define RAWDUMP_MSG_Q_SIZE      (32U)
+
+/**
  * @brief   Stack for the raw dump thread
  */
 static char rawdmp_stack[THREAD_STACKSIZE_MAIN];
@@ -72,12 +77,14 @@ void dump_pkt(gnrc_pktsnip_t *pkt)
  */
 void *rawdump(void *arg)
 {
+    msg_t msg_q[RAWDUMP_MSG_Q_SIZE];
+
     (void)arg;
-    msg_t msg;
-
+    msg_init_queue(msg_q, RAWDUMP_MSG_Q_SIZE);
     while (1) {
-        msg_receive(&msg);
+        msg_t msg;
 
+        msg_receive(&msg);
         switch (msg.type) {
             case GNRC_NETAPI_MSG_TYPE_RCV:
                 dump_pkt((gnrc_pktsnip_t *)msg.content.ptr);


### PR DESCRIPTION
Usually we have a message queue for threads handling GNRC netapi calls. Maybe the absence of one in this application contributes to the packet loss reported at various places.

Usually this reported as an error, but since `DEVELHELP` is not enabled for this application (and it shouldn't), this did not show up.

Fixes #32 (see https://github.com/RIOT-OS/applications/pull/34#issuecomment-398179602)