### PR TITLE
sniffer: script: ignore non-ASCII characters on input

### DIFF
--- a/sniffer/tools/sniffer.py
+++ b/sniffer/tools/sniffer.py
@@ -60,7 +60,7 @@ def configure_interface(port, channel):
             print("Application has no network interface defined",
                   file=sys.stderr)
             sys.exit(2)
-        match = re.search(r'^Iface +(\d+)', line.decode())
+        match = re.search(r'^Iface +(\d+)', line.decode(errors="ignore"))
         if match is not None:
             iface = int(match.group(1))
             break
@@ -85,7 +85,7 @@ def generate_pcap(port, out):
         line = port.readline().rstrip()
 
         pkt_header = re.match(r">? *rftest-rx --- len 0x(\w\w).*",
-                              line.decode())
+                              line.decode(errors="ignore"))
         if pkt_header:
             now = time()
             sec = int(now)
@@ -97,9 +97,9 @@ def generate_pcap(port, out):
             sys.stderr.write("RX: %i\r" % count)
             continue
 
-        pkt_data = re.match(r"(0x\w\w )+", line.decode())
+        pkt_data = re.match(r"(0x\w\w )+", line.decode(errors="ignore"))
         if pkt_data:
-            for part in line.decode().split(' '):
+            for part in line.decode(errors="ignore").split(' '):
                 byte = re.match(r"0x(\w\w)", part)
                 if byte:
                     out.write(pack('<B', int(byte.group(1), 16)))


### PR DESCRIPTION
The sniffer RIOT application doesn't generate non-ASCII characters so it
is safe for the python PCAP-generating script to assume that those
characters are garbage output (e.g. in initialization) and can be
ignored.