### PR TITLE
 sniffer: use fmt instead of printf

### DIFF
--- a/sniffer/Makefile
+++ b/sniffer/Makefile
@@ -8,6 +8,7 @@ BOARD ?= native
 RIOTBASE ?= $(CURDIR)/../../RIOT
 
 # Define modules that are used
+USEMODULE += fmt
 USEMODULE += gnrc
 USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif

--- a/sniffer/main.c
+++ b/sniffer/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
+ * Copyright (C) 2015-18 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -15,12 +15,14 @@
  * @brief       Sniffer application for RIOT
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Martine Lenders <m.lenders@fu-berlin.de>
  *
  * @}
  */
 
 #include <stdio.h>
 
+#include "fmt.h"
 #include "thread.h"
 #include "xtimer.h"
 #include "shell.h"
@@ -59,16 +61,21 @@ void dump_pkt(gnrc_pktsnip_t *pkt)
     pkt = gnrc_pktbuf_remove_snip(pkt, pkt->next);
     uint64_t now_us = xtimer_usec_from_ticks64(xtimer_now64());
 
-    printf("rftest-rx --- len 0x%02x lqi 0x%02x rx_time 0x%08" PRIx32 "%08" PRIx32 "\n\n",
-           gnrc_pkt_len(pkt), lqi, (uint32_t)(now_us >> 32), (uint32_t)(now_us & 0xffffffff));
-
+    print_str("rftest-rx --- len ");
+    print_u32_hex((uint32_t)gnrc_pkt_len(pkt));
+    print_str(" lqi ");
+    print_byte_hex(lqi);
+    print_str(" rx_time ");
+    print_u64_hex(now_us);
+    print_str("\n");
     while (snip) {
         for (size_t i = 0; i < snip->size; i++) {
-            printf("0x%02x ", ((uint8_t *)(snip->data))[i]);
+            print_byte_hex(((uint8_t *)(snip->data))[i]);
+            print_str(" ");
         }
         snip = snip->next;
     }
-    puts("\n");
+    print_str("\n\n");
 
     gnrc_pktbuf_release(pkt);
 }

--- a/sniffer/main.c
+++ b/sniffer/main.c
@@ -47,7 +47,7 @@
 /**
  * @brief   Stack for the raw dump thread
  */
-static char rawdmp_stack[THREAD_STACKSIZE_MAIN];
+static char rawdmp_stack[THREAD_STACKSIZE_SMALL];
 
 /**
  * @brief   Make a raw dump of the given packet contents

--- a/sniffer/tools/sniffer.py
+++ b/sniffer/tools/sniffer.py
@@ -85,7 +85,7 @@ def generate_pcap(port, out):
     while True:
         line = port.readline().rstrip()
 
-        pkt_header = re.match(r">? *rftest-rx --- len 0x(\w\w).*",
+        pkt_header = re.match(r">? *rftest-rx --- len (\w+).*",
                               line.decode(errors="ignore"))
         if pkt_header:
             now = time()
@@ -98,10 +98,10 @@ def generate_pcap(port, out):
             sys.stderr.write("RX: %i\r" % count)
             continue
 
-        pkt_data = re.match(r"(0x\w\w )+", line.decode(errors="ignore"))
+        pkt_data = re.match(r"(\w\w )+", line.decode(errors="ignore"))
         if pkt_data:
             for part in line.decode(errors="ignore").split(' '):
-                byte = re.match(r"0x(\w\w)", part)
+                byte = re.match(r"(\w\w)", part)
                 if byte:
                     out.write(pack('<B', int(byte.group(1), 16)))
             out.flush()


### PR DESCRIPTION
I know this is  a little more extreme change, but I was able to reduce stack usage by 2/3 on `samr21-xpro`. Additionally, I removed the leading `0x` for the hexadecimal numbers. The parsing script knows which numbers are hex (all of them) and they just waste time both on the node and in the parsing script.

(~~Needs to be adapted if #33 is merged before~~ done)