### PR TITLE
 sniffer: make serial/socket command optional

### DIFF
--- a/sniffer/tools/sniffer.py
+++ b/sniffer/tools/sniffer.py
@@ -153,10 +153,9 @@ def main():
                           help="Host of the TCP-based sniffer application")
     socket_p.add_argument("port", type=int,
                           help="Port of the TCP-based sniffer application")
-    for ps in (serial_p, socket_p):
-        ps.add_argument("channel", type=int, help="Channel to sniff on")
-        ps.add_argument("outfile", type=str, default=None, nargs="?",
-                        help="PCAP file to output to")
+    p.add_argument("channel", type=int, help="Channel to sniff on")
+    p.add_argument("outfile", type=str, default=None, nargs="?",
+                   help="PCAP file to output to")
     args = p.parse_args()
 
     conn = connect(args)

--- a/sniffer/tools/sniffer.py
+++ b/sniffer/tools/sniffer.py
@@ -161,7 +161,7 @@ def main():
     conn = connect(args)
 
     sleep(1)
-    configure_interface(conn, int(args.channel))
+    configure_interface(conn, args.channel)
     sleep(1)
 
     # figure out where to write

--- a/sniffer/tools/sniffer.py
+++ b/sniffer/tools/sniffer.py
@@ -33,6 +33,7 @@ SUCH DAMAGE.
 '''
 
 from __future__ import print_function
+import argparse
 import sys
 import re
 import socket
@@ -106,21 +107,21 @@ def generate_pcap(port, out):
             out.flush()
 
 
-def connect(argv):
-    connType = argv[1]
+def connect(args):
+    connType = args.conn_type
 
     conn = None
     if connType == "serial":
         # open serial port
         try:
-            conn = Serial(argv[2], argv[3], dsrdtr=0, rtscts=0,
+            conn = Serial(args.tty, args.baudrate, dsrdtr=0, rtscts=0,
                           timeout=1)
         except IOError:
             print("error opening serial port", file=sys.stderr)
             sys.exit(2)
     elif connType == "socket":
-        host = argv[2]
-        port = int(argv[3])
+        host = args.host
+        port = args.port
 
         try:
             sock = socket.socket()
@@ -135,25 +136,40 @@ def connect(argv):
 
     return conn
 
-def main(argv):
-    if len(argv) < 5:
-        print("Usage: %s serial tty baudrate channel [outfile]\n"
-              "       %s socket host port channel [outfile]" % (argv[0], argv[0]),
-              file=sys.stderr)
-        print("       channel = 11-26", file=sys.stderr)
-        sys.exit(2)
+def main():
+    p = argparse.ArgumentParser()
+    sp = p.add_subparsers(dest="conn_type")
+    serial_p = sp.add_parser("serial",
+                             help="Parse output of sniffer application "
+                                  "connected via serial line")
+    serial_p.add_argument("tty", type=str,
+                          help="Serial port to board with sniffer application")
+    serial_p.add_argument("baudrate", type=int,
+                          help="Baudrate of the serial port")
+    socket_p = sp.add_parser("socket",
+                             help="Parse output of a TCP-connected sniffer "
+                                  "application")
+    socket_p.add_argument("host", type=str,
+                          help="Host of the TCP-based sniffer application")
+    socket_p.add_argument("port", type=int,
+                          help="Port of the TCP-based sniffer application")
+    for ps in (serial_p, socket_p):
+        ps.add_argument("channel", type=int, help="Channel to sniff on")
+        ps.add_argument("outfile", type=str, default=None, nargs="?",
+                        help="PCAP file to output to")
+    args = p.parse_args()
 
-    conn = connect(argv)
+    conn = connect(args)
 
     sleep(1)
-    configure_interface(conn, int(argv[4]))
+    configure_interface(conn, int(args.channel))
     sleep(1)
 
     # figure out where to write
-    try:
-        sys.stderr.write('trying to open file %s\n' % argv[5])
-        outfile = open(argv[5], 'w+b')
-    except IndexError:
+    if args.outfile is not None:
+        sys.stderr.write('trying to open file %s\n' % args.outfile)
+        outfile = open(args.outfile, 'w+b')
+    else:
         if sys.version_info > (3,):
             outfile = sys.stdout.buffer
         else:
@@ -168,4 +184,4 @@ def main(argv):
 
 
 if __name__ == "__main__":
-    main(sys.argv)
+    main()


### PR DESCRIPTION
First of all: I know this is very hacky, but sadly there is no
straight-forward (and portable) way with `argparse` to make a
subcommand optional, like it is the case e.g. with many `git`
commands.

However, this allows now also do just type

```sh
./tools/sniffer /dev/ttyACM0 112500 26
```

Depends on #37