### PR TITLE
sniffer: fix default baudrate in script

### DIFF
--- a/sniffer/tools/sniffer.py
+++ b/sniffer/tools/sniffer.py
@@ -141,7 +141,7 @@ def main():
     else:
         default_outfile = sys.stdout
     p = argparse.ArgumentParser()
-    p.add_argument("-b", "--baudrate", type=int, default=112500,
+    p.add_argument("-b", "--baudrate", type=int, default=115200,
                    help="Baudrate of the serial port (only evaluated "
                         "for non TCP-terminal)")
     p.add_argument("conn", metavar="tty/host:port", type=str,


### PR DESCRIPTION
This fixes a minor typo in the `sniffer.py` script where the default baud rate is set to `112500` instead of `115200`.