### PR TITLE
spektrum scanner: adapt to new gnrc_netif calls

### DIFF
--- a/spectrum-scanner/Makefile
+++ b/spectrum-scanner/Makefile
@@ -2,7 +2,7 @@
 APPLICATION = spectrum-scanner
 
 # If no BOARD is found in the environment, use this default:
-BOARD ?= frdm-kw41z
+BOARD ?= samr21-xpro
 
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../../RIOT


### PR DESCRIPTION
The application does not compile with current RIOT master, this PR fixes that and
adapt the gnrc_netif calls accordingly.

Additionally this PR changes the default board in the Makefile from `frdm-kw41z` to `samr21-xpro` as this seems to be the only board with a radio driver in RIOT that supports the required NETOPT.

To test: try to compile spectrum-scanner in master with current RIOT which will fail. While this PR does work.