### PR TITLE
CI: add travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: required
+
+language: minimal
+
+before_install:
+  - sudo apt-get install coreutils cppcheck pcregrep python3 python3-pip uncrustify
+  - sudo pip3 install flake8
+
+script:
+  - ./RIOT/dist/tools/whitespacecheck/check.sh
+  - find . -path ./RIOT -prune -o -name *.py -exec python3 -m flake8 --config=./RIOT/dist/tools/flake8/flake8.cfg {} +
+  - find . -path ./RIOT -prune -o \( -name *.c -o -name *.h \) -exec cppcheck --std=c99 --enable=style --force --error-exitcode=2 --quiet -j 1 {} +


### PR DESCRIPTION
This PR does a couple of things to enable an initial CI check on applications:

~~1. it add the current/latest RIOT release as a submodule to this repository~~
~~2. RIOTBASE of all application Makefiles is adapted to point to the submodule~~
3. an initial travis.yml is added, that runs some static tests reusing scripts and config from the RIOT submodule
~~4. adds a patch for the `plot_rssi.py` of the spectrum-scanner to fix flake8 errors~~

~~The idea for the future would be that applications always work against the latest RIOT release and as part of the release process the submodule hash is updated every 3 month (or so). That way applications should work from release to release.~~

Note: I think someone with more GitHub rights than me has to enable Travis for this repo (@miri64?).