### PR TITLE
add RIOT as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "RIOT"]
+	path = RIOT
+	url = https://github.com/RIOT-OS/RIOT

--- a/coap-chat/Makefile
+++ b/coap-chat/Makefile
@@ -5,7 +5,7 @@ APPLICATION = coap_chat
 BOARD ?= native
 
 # This has to be the absolute path to the RIOT base directory:
-RIOTBASE ?= $(CURDIR)/../../RIOT
+RIOTBASE ?= $(CURDIR)/../RIOT
 
 USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif

--- a/sniffer/Makefile
+++ b/sniffer/Makefile
@@ -5,7 +5,7 @@ APPLICATION = sniffer
 BOARD ?= native
 
 # This has to be the absolute path to the RIOT base directory:
-RIOTBASE ?= $(CURDIR)/../../RIOT
+RIOTBASE ?= $(CURDIR)/../RIOT
 
 # Define modules that are used
 USEMODULE += fmt

--- a/spectrum-scanner/Makefile
+++ b/spectrum-scanner/Makefile
@@ -5,7 +5,7 @@ APPLICATION = spectrum-scanner
 BOARD ?= samr21-xpro
 
 # This has to be the absolute path to the RIOT base directory:
-RIOTBASE ?= $(CURDIR)/../../RIOT
+RIOTBASE ?= $(CURDIR)/../RIOT
 
 # Define modules that are used
 USEMODULE += gnrc


### PR DESCRIPTION
This adds RIOT as a submodule fixed on the latest official release, i.e., ~~2018.07~~ 2018.10. It also adapts the Makefiles of the ~~2~~ 3 existing apps to use the submodule as RIOTBASE.

The idea would be that the submodule is bumped to the next version (RIOT release) as part of the release process and with that make sure all apps compile and run with the new release. This would
help to allow problems like #47 where the app is broken because of changes to RIOT master.