### PR TITLE
git: add RIOT submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "RIOT"]
+	path = RIOT
+	url = git@github.com:RIOT-OS/RIOT.git

--- a/sniffer/Makefile
+++ b/sniffer/Makefile
@@ -5,7 +5,7 @@ APPLICATION = sniffer
 BOARD ?= native
 
 # This has to be the absolute path to the RIOT base directory:
-RIOTBASE ?= $(CURDIR)/../../RIOT
+RIOTBASE ?= $(CURDIR)/../RIOT
 
 # Define modules that are used
 USEMODULE += fmt

--- a/spectrum-scanner/Makefile
+++ b/spectrum-scanner/Makefile
@@ -5,7 +5,7 @@ APPLICATION = spectrum-scanner
 BOARD ?= frdm-kw41z
 
 # This has to be the absolute path to the RIOT base directory:
-RIOTBASE ?= $(CURDIR)/../../RIOT
+RIOTBASE ?= $(CURDIR)/../RIOT
 
 # Define modules that are used
 USEMODULE += gnrc


### PR DESCRIPTION
This PR adds the latest RIOT release (2018.07) as a git submodule.

This way, it's prevented to break the applications if something changes in the master branch. Also, if we test against a fixed version (Release), we can ensure the applications will work.

We would need idea to update the submodule and test the applications at the end of every release.


NB: The `spectrum-scanner` application is broken, and will be fixed in another PR.