### PR TITLE
spectrum-scanner: Improved plotting script

### DIFF
--- a/spectrum-scanner/tools/plot_rssi.py
+++ b/spectrum-scanner/tools/plot_rssi.py
@@ -73,7 +73,7 @@ class RSSIPlot(object):
         # X and Y are the bounds, so Z should be the value *inside* those bounds.
         # Therefore, remove the last row and column from the Z array.
         self.Z = Z[:-1, :-1]
-        self.pcm = self.ax.pcolormesh(self.X, self.Y, self.Z, vmin=-128, vmax=0, cmap=plt.cm.get_cmap('jet'))
+        self.pcm = self.ax.pcolormesh(self.X, self.Y, self.Z, vmin=-100, vmax=-20, cmap=plt.cm.get_cmap('jet'))
         self.ax.get_figure().colorbar(self.pcm, label="Measured signal level [dB]")
         self.ax.set_ylabel("Channel number")
         self.ax.set_xlabel("Time [s]")


### PR DESCRIPTION
This is a rewrite of the plotting script used by the spectrum scanner.

Improvements:

 - No longer steals window focus at each data update
 - Uses matplotlib's animation API for live updates, instead of manually re-plotting on a timer loop
 - Newest values are always at the right hand side of the plot area
 - Added workaround for issue mentioned in https://github.com/RIOT-OS/RIOT/pull/1437/commits/73f6a0c51815144a128f3a368fafae73b1b69215 (problem was observed with FRDM-KW41Z)