### PR TITLE
sniffer: Check for missing netif header in dump_pkt

### DIFF
--- a/sniffer/main.c
+++ b/sniffer/main.c
@@ -55,10 +55,14 @@ static char rawdmp_stack[THREAD_STACKSIZE_SMALL];
 void dump_pkt(gnrc_pktsnip_t *pkt)
 {
     gnrc_pktsnip_t *snip = pkt;
-    gnrc_netif_hdr_t *netif_hdr = pkt->next->data;
-    uint8_t lqi = netif_hdr->lqi;
-
-    pkt = gnrc_pktbuf_remove_snip(pkt, pkt->next);
+    uint8_t lqi = 0;
+    if (pkt->next) {
+        if (pkt->next->type == GNRC_NETTYPE_NETIF) {
+            gnrc_netif_hdr_t *netif_hdr = pkt->next->data;
+            lqi = netif_hdr->lqi;
+            pkt = gnrc_pktbuf_remove_snip(pkt, pkt->next);
+        }
+    }
     uint64_t now_us = xtimer_usec_from_ticks64(xtimer_now64());
 
     print_str("rftest-rx --- len ");


### PR DESCRIPTION
Avoids a hard fault when using the latest RIOT master where raw mode does not provide a netif header.

The sniffer application works without this PR on samr21-xpro, but only because of luck.
https://github.com/RIOT-OS/applications/blob/39a974efcae7161b0b319972a55b3d60c171076a/sniffer/main.c#L61 `pkt->next` is NULL and the pktbuf_remove call causes an indirect write: `pkt->next->next = NULL;`

On frdm-kw41z (with RIOT-OS/RIOT#7107) the null pointer write causes a hard fault

for reference, here is the called function where the write happens: https://github.com/RIOT-OS/RIOT/blob/f139dfdad2c81f239e27e2be86a7857e740dc201/sys/net/gnrc/pktbuf/gnrc_pktbuf.c#L54-L62