### PR TITLE
coap-chat: 2019.10 update

### DIFF
--- a/coap-chat/coap.c
+++ b/coap-chat/coap.c
@@ -40,6 +40,7 @@ static const coap_resource_t _resources[] = {
 static gcoap_listener_t _listener = {
     &_resources[0],
     sizeof(_resources) / sizeof(_resources[0]),
+    NULL,
     NULL
 };
 


### PR DESCRIPTION
### Contribution description
Fixes straightforward compilation issue due to upstream change to gcoap in 2019.10 release.

### Testing procedure
Compile for native, use `tapsetup` to create a couple of tap interfaces, then try a short chat.

### Issues/PRs references
Depends on #67
