### PR TITLE
RIOT: bump version to 2020.01

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,15 @@ cd applications
 RIOTBASE="../RIOT" BOARD=samr21-xpro make -C sniffer flash
 ```
 
-Alternatively, you can step into the submodule and check out the current master:
+Alternatively you can use RIOT as a submodule. To initialize the submodule, from the
+root of the repository run:
+
+```sh
+git submodule update --init --recursive
+```
+
+If you want to use master then simply step into the submodule and checkout master or
+any other desired branch.
 
 ```sh
 cd RIOT

--- a/coap-chat/coap.c
+++ b/coap-chat/coap.c
@@ -63,8 +63,8 @@ static size_t _send(uint8_t *buf, size_t len, char *addr_str)
     remote.family = AF_INET6;
 
     /* parse for interface */
-    int iface = ipv6_addr_split_iface(addr_str);
-    if (iface == -1) {
+    char *iface = ipv6_addr_split_iface(addr_str);
+    if (!iface) {
         if (gnrc_netif_numof() == 1) {
             /* assign the single interface found in gnrc_netif_numof() */
             remote.netif = (uint16_t)gnrc_netif_iter(NULL)->pid;
@@ -74,11 +74,11 @@ static size_t _send(uint8_t *buf, size_t len, char *addr_str)
         }
     }
     else {
-        if (gnrc_netif_get_by_pid(iface) == NULL) {
+        if (gnrc_netif_get_by_pid(atoi(iface)) == NULL) {
             DEBUG("[CoAP] interface not valid");
             return 0;
         }
-        remote.netif = iface;
+        remote.netif = atoi(iface);
     }
 
     /* parse destination address */
@@ -95,7 +95,7 @@ static size_t _send(uint8_t *buf, size_t len, char *addr_str)
     /* parse port */
     remote.port = GCOAP_PORT;
 
-    return gcoap_req_send2(buf, len, &remote, NULL);
+    return gcoap_req_send(buf, len, &remote, NULL, NULL);
 }
 
 int coap_post(char *addr, char *msgbuf, size_t msglen)


### PR DESCRIPTION
This PR bump the version to the latest release and fixes the README submodule init code.


Applications test:

- sniffer

```
/workspace/riot-applications/sniffer/tools/sniffer.py -b 500000 /dev/riot/tty-iotlab-m3 26 | wireshark -k -i -
ifconfig 3 set chan 26
ifconfig 3 raw
ifconfig 3 promisc
```

![image](https://user-images.githubusercontent.com/23060007/73828431-86165880-4801-11ea-8cd0-e7906ad55b5f.png)


- spectrum scanner:

```
2020-02-05 10:13:36,259 # [0, 502287, 42] 11: -87.8340, 12: -84.1664, 13: -86.3273, 14: -87.2096, 15: -90.1427, 16: -90.0974, 17: -90.4618, 18: -90.5094, 19: -88.6544, 20: -88.8523, 21: -89.8233, 22: -87.4000, 23: -90.7352, 24: -90.9999, 25: -90.9999, 26: -90.9999, 
2020-02-05 10:13:36,262 # [0, 1013032, 42] 11: -89.3162, 12: -87.2324, 13: -85.8784, 14: -88.8112, 15: -90.2932, 16: -90.3245, 17: -90.7360, 18: -88.1828, 19: -87.0150, 20: -87.8800, 21: -90.8786, 22: -89.7652, 23: -90.6122, 24: -90.9999, 25: -90.9999, 26: -90.9999, 
2020-02-05 10:13:36,510 # [0, 1523818, 42] 11: -86.9142, 12: -88.0809, 13: -85.0034, 14: -88.5175, 15: -90.3134, 16: -90.2273, 17: -90.0246, 18: -89.7198, 19: -90.5948, 20: -89.0474, 21: -90.7267, 22: -89.8240, 23: -90.7846, 24: -90.9999, 25: -90.9999, 26: -90.9999, 
```

![image](https://user-images.githubusercontent.com/23060007/73828313-4e0f1580-4801-11ea-929f-ae0d0134bf90.png)


- coap-chat:

```
main(): This is RIOT! (Version: 2020.01)
All up, running the shell now
> help
help
Command              Description
---------------------------------------
chat                 CoAP chat
reboot               Reboot the node
ping6                Ping via ICMPv6
random_init          initializes the PRNG
random_get           returns 32 bit of pseudo randomness
nib                  Configure neighbor information base
ifconfig             Configure network interfaces
> ifconfig
ifconfig
Iface  6  HWaddr: 72:87:22:6B:D1:FF 
          L2-PDU:1500 MTU:1500  HL:64  Source address length: 6
          Link type: wired
          inet6 addr: fe80::7087:22ff:fe6b:d1ff  scope: link  VAL
          inet6 group: ff02::1
          inet6 group: ff02::1:ff6b:d1ff
          
> chat fe80::c86a:6bff:feed:1f33 fjmolinas hello
chat fe80::c86a:6bff:feed:1f33 fjmolinas hello
> 
[ CHAT ] francisco: hi!

```

```
main(): This is RIOT! (Version: 2020.01)
All up, running the shell now
> help
help
Command              Description
---------------------------------------
chat                 CoAP chat
reboot               Reboot the node
ping6                Ping via ICMPv6
random_init          initializes the PRNG
random_get           returns 32 bit of pseudo randomness
nib                  Configure neighbor information base
ifconfig             Configure network interfaces
> caht
caht
shell: command not found: caht
> chat
chat
usage: chat <addr> <nick> <msg>
> ifconfig
ifconfig
Iface  6  HWaddr: CA:6A:6B:ED:1F:33 
          L2-PDU:1500 MTU:1500  HL:64  Source address length: 6
          Link type: wired
          inet6 addr: fe80::c86a:6bff:feed:1f33  scope: link  VAL
          inet6 group: ff02::1
          inet6 group: ff02::1:ffed:1f33
          
> 
[ CHAT ] fjmolinas: hello

chat fe80::7087:22ff:fe6b:d1ff francisco hi!  
chat fe80::7087:22ff:fe6b:d1ff francisco hi!
```
