### PR TITLE
coap-chat: adapt to new gcoap API

### DIFF
--- a/coap-chat/main.c
+++ b/coap-chat/main.c
@@ -22,7 +22,6 @@
 #include "msg.h"
 
 #include "net/gcoap.h"
-#include "kernel_types.h"
 #include "shell.h"
 
 #define BUFLEN          (64U)


### PR DESCRIPTION
This adapts the coap-chat application to use the new gcoap API, as `gcoap_finish` has been deprecated and removed. Also, removes the inclusion of `kernel_types.h` which has been removed as well.

### Test
Run the application following the README, it should compile and work as usual.
