### PR TITLE
RIOT-OS Submodule : Update to 2022.07 release

### DIFF
--- a/coap-chat/Makefile
+++ b/coap-chat/Makefile
@@ -7,7 +7,7 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../RIOT
 
-USEMODULE += gnrc_netdev_default
+USEMODULE += netdev_default
 USEMODULE += auto_init_gnrc_netif
 # Specify the mandatory networking modules
 USEMODULE += gnrc_ipv6_default

--- a/coap-chat/coap.c
+++ b/coap-chat/coap.c
@@ -30,7 +30,7 @@
 
 #define COAP_CHAT_PATH      "/chat"
 
-static ssize_t _chat_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx);
+static ssize_t _chat_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, coap_request_ctx_t *ctx);
 
 /* CoAP resources */
 static const coap_resource_t _resources[] = {
@@ -43,7 +43,7 @@ static gcoap_listener_t _listener = {
     .next = NULL,
 };
 
-static ssize_t _chat_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx)
+static ssize_t _chat_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, coap_request_ctx_t *ctx)
 {
     (void)ctx;
 

--- a/sniffer/Makefile
+++ b/sniffer/Makefile
@@ -16,6 +16,7 @@ USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
 USEMODULE += xtimer
+USEMODULE += ztimer64_xtimer_compat
 
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1

--- a/sniffer/Makefile
+++ b/sniffer/Makefile
@@ -10,7 +10,7 @@ RIOTBASE ?= $(CURDIR)/../RIOT
 # Define modules that are used
 USEMODULE += fmt
 USEMODULE += gnrc
-USEMODULE += gnrc_netdev_default
+USEMODULE += netdev_default
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += shell
 USEMODULE += shell_commands

--- a/sniffer/Makefile
+++ b/sniffer/Makefile
@@ -15,8 +15,7 @@ USEMODULE += auto_init_gnrc_netif
 USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
-USEMODULE += xtimer
-USEMODULE += ztimer64_xtimer_compat
+USEMODULE += ztimer64_usec
 
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1

--- a/sniffer/main.c
+++ b/sniffer/main.c
@@ -24,9 +24,9 @@
 
 #include "fmt.h"
 #include "thread.h"
-#include "xtimer.h"
 #include "shell.h"
 #include "net/gnrc.h"
+#include "ztimer64.h"
 
 /**
  * @brief   Buffer size used by the shell
@@ -62,14 +62,14 @@ void dump_pkt(gnrc_pktsnip_t *pkt)
             pkt = gnrc_pktbuf_remove_snip(pkt, pkt->next);
         }
     }
-    uint64_t now = xtimer_now64();
+    uint64_t now_us = ztimer64_now(ZTIMER64_USEC);
 
     print_str("rftest-rx --- len ");
     print_u32_hex((uint32_t)gnrc_pkt_len(pkt));
     print_str(" lqi ");
     print_byte_hex(lqi);
     print_str(" rx_time ");
-    print_u64_hex(now);
+    print_u64_hex(now_us);
     print_str("\n");
     while (snip) {
         for (size_t i = 0; i < snip->size; i++) {

--- a/sniffer/main.c
+++ b/sniffer/main.c
@@ -26,7 +26,6 @@
 #include "thread.h"
 #include "xtimer.h"
 #include "shell.h"
-#include "shell_commands.h"
 #include "net/gnrc.h"
 
 /**
@@ -63,14 +62,14 @@ void dump_pkt(gnrc_pktsnip_t *pkt)
             pkt = gnrc_pktbuf_remove_snip(pkt, pkt->next);
         }
     }
-    uint64_t now_us = xtimer_usec_from_ticks64(xtimer_now64());
+    uint64_t now = xtimer_now64();
 
     print_str("rftest-rx --- len ");
     print_u32_hex((uint32_t)gnrc_pkt_len(pkt));
     print_str(" lqi ");
     print_byte_hex(lqi);
     print_str(" rx_time ");
-    print_u64_hex(now_us);
+    print_u64_hex(now);
     print_str("\n");
     while (snip) {
         for (size_t i = 0; i < snip->size; i++) {

--- a/spectrum-scanner/Makefile
+++ b/spectrum-scanner/Makefile
@@ -9,7 +9,7 @@ RIOTBASE ?= $(CURDIR)/../RIOT
 
 # Define modules that are used
 USEMODULE += gnrc
-USEMODULE += gnrc_netdev_default
+USEMODULE += netdev_default
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += xtimer
 USEMODULE += ztimer64_xtimer_compat

--- a/spectrum-scanner/Makefile
+++ b/spectrum-scanner/Makefile
@@ -12,6 +12,7 @@ USEMODULE += gnrc
 USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += xtimer
+USEMODULE += ztimer64_xtimer_compat
 USEMODULE += fmt
 
 # Change this to 0 show compiler invocation lines by default:


### PR DESCRIPTION
Update the submodule version. Apparently, release managers forget about this. 

Disclaimer I could not test the existing applications. I wanted to update the submodule so that I can use the latest boards.
